### PR TITLE
feat: integrate wagmi and magic in nextjs demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+.env*
+.DS_Store

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "wagmi-magic-connector-demo-nextjs",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "wagmi": "^2.10.1",
+    "viem": "^2.7.1",
+    "@magiclabs/wagmi-connector": "^0.1.5"
+  },
+  "devDependencies": {
+    "typescript": "5.3.3",
+    "@types/react": "18.2.46",
+    "@types/node": "20.10.5",
+    "eslint": "8.56.0",
+    "eslint-config-next": "14.1.0"
+  }
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,36 @@
+import type { AppProps } from 'next/app'
+import { WagmiConfig, configureChains, createConfig } from 'wagmi'
+import { publicProvider } from 'wagmi/providers/public'
+import { mainnet } from 'wagmi/chains'
+import { metaMask } from 'wagmi/connectors/metaMask'
+import { MagicConnector } from '@magiclabs/wagmi-connector'
+import '../styles/globals.css'
+
+const { chains, publicClient, webSocketPublicClient } = configureChains(
+  [mainnet],
+  [publicProvider()],
+)
+
+const connectors = [
+  metaMask(),
+  new MagicConnector({
+    options: {
+      apiKey: process.env.NEXT_PUBLIC_MAGIC_API_KEY || '',
+    },
+  }),
+]
+
+const config = createConfig({
+  autoConnect: true,
+  connectors,
+  publicClient,
+  webSocketPublicClient,
+})
+
+export default function App({ Component, pageProps }: AppProps) {
+  return (
+    <WagmiConfig config={config}>
+      <Component {...pageProps} />
+    </WagmiConfig>
+  )
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,42 @@
+import { useAccount, useConnect, useDisconnect } from 'wagmi'
+import { useState } from 'react'
+
+export default function Home() {
+  const { address, isConnected } = useAccount()
+  const { connect, connectors, error } = useConnect()
+  const { disconnect } = useDisconnect()
+  const [connecting, setConnecting] = useState(false)
+
+  const handleConnect = async () => {
+    setConnecting(true)
+    try {
+      // Try MetaMask first
+      await connect({ connector: connectors[0] })
+    } catch {
+      const magic = connectors.find((c) => c.id === 'magic')
+      if (magic) {
+        await connect({ connector: magic })
+      }
+    } finally {
+      setConnecting(false)
+    }
+  }
+
+  if (isConnected) {
+    return (
+      <div>
+        <p>Connected as {address}</p>
+        <button onClick={() => disconnect()}>Disconnect</button>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <button onClick={handleConnect} disabled={connecting}>
+        {connecting ? 'Connecting...' : 'Connect Wallet'}
+      </button>
+      {error && <p>{error.message}</p>}
+    </div>
+  )
+}

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,24 @@
-Nextjs demo
+# Next.js Wagmi Magic Connector Demo
+
+This demo showcases a minimal Next.js application with a single wallet connect button.
+It integrates the MetaMask connector from [`wagmi`](https://wagmi.sh) and the
+[`@magiclabs/wagmi-connector`](https://docs.magic.link) to allow passwordless
+Magic Wallet connections.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Set your Magic publishable key in an `.env.local` file:
+   ```bash
+   NEXT_PUBLIC_MAGIC_API_KEY=YOUR_KEY
+   ```
+3. Run the development server:
+   ```bash
+   npm run dev
+   ```
+
+The app exposes a single **Connect Wallet** button. It attempts to connect
+with MetaMask first and falls back to Magic if MetaMask is unavailable.

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,11 @@
+html,
+body {
+  padding: 0;
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
+    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js demo project
- configure wagmi with MetaMask and Magic connectors
- add single connect button that falls back to Magic when MetaMask is unavailable

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_689533a6d51883319a5b244edba99c15